### PR TITLE
Compatibility with Alpha9 (#60)

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,7 @@ name: Specter
 version: 0.4
 author: Falkirks
 main: specter\Specter
-api: [3.0.0-ALPHA7]
+api: [3.0.0-ALPHA9]
 softdepend: ["iControlU"]
 commands:
   specter:

--- a/src/specter/Specter.php
+++ b/src/specter/Specter.php
@@ -7,6 +7,7 @@ use pocketmine\command\CommandSender;
 use pocketmine\entity\Entity;
 use pocketmine\event\Listener;
 use pocketmine\event\player\cheat\PlayerIllegalMoveEvent;
+use pocketmine\math\Vector3;
 use pocketmine\network\mcpe\protocol\InteractPacket;
 use pocketmine\network\mcpe\protocol\MovePlayerPacket;
 use pocketmine\network\mcpe\protocol\RespawnPacket;
@@ -79,11 +80,8 @@ class Specter extends PluginBase implements Listener {
                         $player = $this->getServer()->getPlayer($args[1]);
                         if($player instanceof SpecterPlayer){
                             $pk = new MovePlayerPacket();
-                            $pk->x = $args[2];
-                            $pk->y = $args[3] + $player->getEyeHeight();
-                            $pk->z = $args[4];
+                            $pk->position = new Vector3($args[2],$args[3] + $player->getEyeHeight(),$args[4]);
                             $pk->yaw = $player->getYaw()+10; //This forces movement even if the movement is not large enough
-                            $pk->bodyYaw = 0;
                             $pk->pitch = 0;
                             $this->interface->queueReply($pk, $player->getName());
                         }

--- a/src/specter/network/SpecterInterface.php
+++ b/src/specter/network/SpecterInterface.php
@@ -1,6 +1,7 @@
 <?php
 namespace specter\network;
 
+use pocketmine\entity\Skin;
 use pocketmine\network\mcpe\protocol\BatchPacket;
 use pocketmine\network\mcpe\protocol\DataPacket;
 use pocketmine\network\mcpe\protocol\LoginPacket;
@@ -118,7 +119,7 @@ class SpecterInterface implements SourceInterface{
                     break;
                 case MovePlayerPacket::class:
                 	/** @var MovePlayerPacket $packet */
-                    $eid = isset($packet->entityRuntimeId) ? $packet->entityRuntimeId : $packet->eid; //backwards-compatibility
+                    $eid = $packet->entityRuntimeId;
                     if($eid === $player->getId() && $player->isAlive() && $player->spawned === true && $player->getForceMovement() !== null) {
                         $packet->mode = MovePlayerPacket::MODE_NORMAL;
                         $packet->yaw += 25; //FIXME little hacky
@@ -184,13 +185,13 @@ class SpecterInterface implements SourceInterface{
                 }
             };
             $pk->username = $username;
-            $pk->gameEdition = 0;
             $pk->protocol = ProtocolInfo::CURRENT_PROTOCOL;
             $pk->clientUUID = UUID::fromData($address, $port, $username)->toString();
             $pk->clientId = 1;
             $pk->identityPublicKey = "key here";
-            $pk->skin = str_repeat("\x80", 64 * 32 * 4);
-            $pk->skinId = "Standard_Alex";
+            $pk->clientData["SkinId"] = "Specter";
+            $pk->clientData["SkinData"] = base64_encode(str_repeat("\x80", 64 * 32 * 4));
+            $pk->skipVerification = true;
 
             $pk->handle($player->getSessionAdapter());
 


### PR DESCRIPTION
* Compatibility with Alpha9

This update breaks BC.  Updated skin methods to match the new skin api.  Hard coded standard Alex skin data.  Updated handling of location to use Vector3.  Removed obsolete variables.

* No More Ugly Code

Replaced hard coded skin with generated Specter skin.  Yay pretty code.

* Fix Formatting Error

Tabs and spaces.  Ugh, why can't we all just get along.

* So apparently ...

SkinId doesn't need to be encoded.  Thanks @dktapps!